### PR TITLE
Add community games page

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,3 +3,4 @@ More to come once we get our content organized!
 - [Getting Started](getting-started/getting-started)
 - [FAQ](other/faq)
 - [Stellar Blind-Friendly Games](other/stellar-blind-friendly-games)
+- [Community Games](other/community-games)

--- a/other/community-games.md
+++ b/other/community-games.md
@@ -9,7 +9,7 @@ We could have write-ups for a few stellar entries, before listing all of them al
 
 ## Games for Blind Gamers 1
 [Games For Blind Gamers 1](https://itch.io/jam/games-for-blind-gamers) began on November 20, 2021 and lasted for one month.
-It received 16 submissions:
+It received 15 submissions:
 - [A Quiet Space](https://saoigames.itch.io/a-quiet-space)
 - [Base Dolphin](https://nsix.itch.io/base-dolphin)
 - [Blind Command](https://vaudio.itch.io/blind-command)

--- a/other/community-games.md
+++ b/other/community-games.md
@@ -1,0 +1,64 @@
+# Community games
+We host game jams which receive a variety of cool submissions.
+
+<!--
+Editorial note:
+Do we want to call out notable submissions here?
+We could have write-ups for a few stellar entries, before listing all of them alphabetically at the end of each section.
+-->
+
+## Games for Blind Gamers 1
+[Games For Blind Gamers 1](https://itch.io/jam/games-for-blind-gamers) began on November 20, 2021 and lasted for one month.
+It received 16 submissions:
+- [A Quiet Space](https://saoigames.itch.io/a-quiet-space)
+- [Base Dolphin](https://nsix.itch.io/base-dolphin)
+- [Blind Command](https://vaudio.itch.io/blind-command)
+- [Blindfolded Chef](https://frog-panda.itch.io/blindfolded-chef)
+- [conjecture](https://suzimoocow.itch.io/conjecture)
+- [Crimson Trials](https://bitwixt.itch.io/crimson-trials)
+- [Echomaze](https://spacefetus.itch.io/echomaze)
+- [Klepie](https://drnlab.itch.io/kelpie)
+- [Labyrinth](https://isolation.itch.io/labyrinth)
+- [Lucky Strike](https://origamez.itch.io/lucky-strike)
+- [Museful](https://rafacarneros.itch.io/museful)
+- [Robo-Walk](https://headphaseaudio.itch.io/robo-walk)
+- [Snow Ride](https://vojay.itch.io/audio-snow-ride)
+- [Symfony of Soil](https://ericbomb.itch.io/symphony-of-soil)
+- [The eyes behind the wall](https://comandogdev.itch.io/the-eyes-behind-the-wall)
+
+## Games for Blind Gamers 2
+[Games For Blind Gamers 2](https://itch.io/jam/games-for-blind-gamers-2) began on March 31, 2023 and lasted for one month.
+It received 30 submissions:
+- [Agent Stealth](https://felipe-sound.itch.io/agent-stealth)
+- [Audio Hero](https://perfect-c-games.itch.io/audio-hero)
+- [Audio Missile Command](https://keolinsk.itch.io/audio-missile-command)
+- [cloudskippin](https://stratifarm.itch.io/cloudskippin-jam)
+- [Cowboy's Chorus](https://zclipse.itch.io/cowboys-chorus)
+- [Cryptid's Chasm](https://kersed.itch.io/cryptids-chasm)
+- [Dryads Sun](https://arnebab.itch.io/dryads-sun)
+- [Dying to Speak](https://dyulai.itch.io/dying-to-speak)
+- [Espacio](https://jdzz100.itch.io/espacio)
+- [Ear Hacker](https://jcroisant.itch.io/ear-hacker-jam)
+- [Fighting the voices](https://aquiles-m.itch.io/fighting-the-voices)
+- [Fishyphus](https://shiftbacktick.itch.io/fishyphus)
+- [Greene Bean](https://fullmetalashley.itch.io/gfbg-2023)
+- [Hear you again](https://urbanzero.itch.io/hear-you-again)
+- [Honeycomb Festival](https://dvalkyrie.itch.io/honeycomb-festival)
+- [Hybrid](https://deengames.itch.io/hybrid)
+- [Lifeforms](https://thewrongjohn.itch.io/lifeforms)
+- [Luna: The Lost child](https://espressobuns.itch.io/luna-the-lost-child)
+- [MemTones](https://raconteur81.itch.io/memtones)
+- [Midnight Echoes](https://bowman.itch.io/midnight-echoes)
+- [Mystery Artifact](https://nifflas.itch.io/mystery-artifact)
+- [Parting Gifts](https://eileencalub.itch.io/parting-gifts)
+- [Repeat the Sounds](https://kethram.itch.io/repeat-the-sounds)
+- [RevMatch](https://jordanfb.itch.io/revmatch)
+- [Sentience](https://tallguyprods.itch.io/sentience)
+- [Shadow Caverns](https://jairm.itch.io/shadowcaverns)
+- [Stormy Mole Hill](https://l0aurore.itch.io/stormy-mole-hole)
+- [The Blind Gladiator](https://choollol.itch.io/the-blind-gladiator)
+- [The Fourth Dragon](https://ericbomb.itch.io/the-fourth-dragon)
+- [The Woman in the Cave](https://eibriel.itch.io/the-woman-in-the-cave)
+
+## Games for Blind Gamers 3
+[Games for Blind Gamers 3](https://itch.io/jam/games-for-blind-gamers-3) began on February 1, 2024. _This jam is ongoing._


### PR DESCRIPTION
Here's a simple framework for celebrating community-created games, listed alphabetically for each jam. There is a hidden editorial note which suggests where the page could go next.